### PR TITLE
Add consistent JSON error responses with structured error codes

### DIFF
--- a/src/aggregation/responses.ts
+++ b/src/aggregation/responses.ts
@@ -1,56 +1,64 @@
-/**
- * It's not you, it's us.
- */
-export class FiveHundredResponse {
-  constructor(message: string, errorCode: number) {
+class ErrorResponse {
+  constructor(
+    message: string,
+    readonly errorCode: number,
+    error: string,
+  ) {
     this.message = message;
-    this.errorCode = errorCode;
+    this.error = error;
   }
 
   message: string;
-  errorCode: number;
-}
+  error: string;
 
-export class InternalErrorResponse extends FiveHundredResponse {
-  constructor() {
-    super("Internal error", 500);
+  toJSON() {
+    return { error: this.error, message: this.message };
   }
 }
 
 /**
  * It's not us, it's you.
  */
-export class FourHundredResponse {
-  constructor(message: string, errorCode: number) {
-    this.message = message;
-    this.errorCode = errorCode;
-  }
-
-  message: string;
-  errorCode: number;
-}
+export class FourHundredResponse extends ErrorResponse {}
 
 export class InvalidEmail extends FourHundredResponse {
   constructor() {
-    super("Invalid email address.", 400);
+    super("Invalid email address.", 400, "invalid_email");
   }
 }
 
 export class UnrecognizedParameters extends FourHundredResponse {
   constructor(message: string) {
-    super("Unrecognized parameters: " + message, 400);
+    super("Unrecognized parameters: " + message, 400, "unrecognized_parameters");
   }
 }
 
 export class InvalidParameter extends FourHundredResponse {
   constructor(message: string) {
-    super("Invalid parameter: " + message, 400);
+    super("Invalid parameter: " + message, 400, "invalid_parameter");
   }
 }
 
 export class TooManyIdentifiers extends FourHundredResponse {
   constructor(message: string) {
-    super(message, 400);
+    super(message, 400, "too_many_identifiers");
+  }
+}
+
+export class UnauthorizedResponse extends FourHundredResponse {
+  constructor() {
+    super("Unauthorized", 401, "unauthorized");
+  }
+}
+
+/**
+ * It's not you, it's us.
+ */
+export class FiveHundredResponse extends ErrorResponse {}
+
+export class InternalErrorResponse extends FiveHundredResponse {
+  constructor() {
+    super("Internal error", 500, "internal_error");
   }
 }
 
@@ -82,7 +90,7 @@ interface Facet {
   field: string;
   type: string;
   buckets: Bucket[];
-  bucketsLabel: String;
+  bucketsLabel: string;
 }
 
 interface Bucket {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   DPLADocList,
   FourHundredResponse,
   FiveHundredResponse,
+  UnauthorizedResponse,
   EmailSent,
 } from "./aggregation/responses";
 import ApiKeyRepository from "./aggregation/api_key_repository";
@@ -115,12 +116,14 @@ function worker() {
     }
 
     if (!apiKeyRepository.isApiKeyValid(apiKey)) {
-      return res.status(401).json({ message: "Unauthorized" });
+      const r = new UnauthorizedResponse();
+      return res.status(r.errorCode).json(r);
     }
     const user = await apiKeyRepository.findUserByApiKey(apiKey);
 
     if (!user) {
-      return res.status(401).json({ message: "Unauthorized" });
+      const r = new UnauthorizedResponse();
+      return res.status(r.errorCode).json(r);
     }
 
     next();
@@ -136,14 +139,11 @@ function worker() {
 
   const queryParams = (req: express.Request): Map<string, string> => {
     const params = new Map<string, string>();
-    for (const key in Object.entries(req.query)) {
-      if (req.query.hasOwnProperty(key)) {
-        const value = req.query[key];
-        if (typeof value === "string") {
-          params.set(key, value);
-        } else if (Array.isArray(value)) {
-          params.set(key, value[0] as string);
-        }
+    for (const [key, value] of Object.entries(req.query)) {
+      if (typeof value === "string") {
+        params.set(key, value);
+      } else if (Array.isArray(value)) {
+        params.set(key, value[0] as string);
       }
     }
     return params;


### PR DESCRIPTION
## Summary

- All error responses now include a machine-readable `error` field alongside `message` (e.g. `{"error": "unauthorized", "message": "Unauthorized"}`)
- Consolidates the now-identical `FourHundredResponse` and `FiveHundredResponse` behind a shared `ErrorResponse` base class
- Adds `UnauthorizedResponse` class; authMiddleware now uses it instead of inline literals
- Fixes a `for...in` / `for...of` bug in `queryParams` that silently dropped all query parameters (iterating `Object.entries()` with `for...in` yields index strings, not `[key, value]` pairs)

## Error format

Before:
```json
{"message": "Unauthorized"}
```

After:
```json
{"error": "unauthorized", "message": "Unauthorized"}
```

All existing subclasses (`InvalidEmail`, `UnrecognizedParameters`, `InvalidParameter`, `TooManyIdentifiers`, `InternalErrorResponse`) carry their own error codes unchanged.

## Test plan

- [ ] `GET /items` with no API key → `401 {"error": "unauthorized", "message": "Unauthorized"}`
- [ ] `GET /items` with invalid API key → `401 {"error": "unauthorized", "message": "Unauthorized"}`
- [ ] `GET /items?q=dogs` with valid API key → `200` with results
- [ ] `GET /items?badparam=x` → `400 {"error": "unrecognized_parameters", "message": "Unrecognized parameters: badparam"}`
- [ ] Query parameter values reach the search controller (regression for the for...in fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds structured, machine-readable error codes to all JSON error responses throughout the API. All error responses now include both an `error` field with a machine-readable code (e.g., `"unauthorized"`, `"invalid_email"`, `"internal_error"`) and a human-readable `message` field.

### Key Changes

**Response Structure (Public API)**
- Introduces an `ErrorResponse` base class that adds a structured `error` field to all error responses
- Example: `{"error": "unauthorized", "message": "Unauthorized"}` (previously just `{"message": "Unauthorized"}`)
- All existing error subclasses (`InvalidEmail`, `UnrecognizedParameters`, `InvalidParameter`, `TooManyIdentifiers`, `InternalErrorResponse`) now include consistent error codes

**Auth Middleware**
- Adds a new `UnauthorizedResponse` class (401 status) for authentication failures
- Replaces hardcoded `{ message: "Unauthorized" }` responses with structured `UnauthorizedResponse` instances in both API key validation paths
- Uses `res.status(r.errorCode).json(r)` pattern for consistent error handling

**Bug Fix**
- Fixes a bug in `queryParams` extraction where incorrect loop syntax with `Object.entries()` was causing query parameter values to be silently dropped
- Now correctly iterates over query parameters and maps both string and array values to the returned Map

### API Impact

**⚠️ Public API Response Shape Change**: This is a breaking change for clients expecting the previous error response format. All error responses now include the `error` field alongside `message`.

### No Deployment Changes Required
- No environment variables added/removed/modified
- No database migrations
- No infrastructure configuration changes
- No manual pipeline trigger or ECS redeployment required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->